### PR TITLE
Improve games list UI

### DIFF
--- a/games/models.py
+++ b/games/models.py
@@ -82,18 +82,8 @@ class Game(CoreModel):
         super().save(*args, **kwargs)
 
     def location_display(self):
-        # Display city first, if available
         city_name = self.city.name if self.city else None
-
-        # Use the region code if we have a city, otherwise use the region name
-        if city_name and self.region:
-            region_part = (
-                self.region.geoname_code
-                if self.region.geoname_code
-                else self.region.name
-            )
-        else:
-            region_part = self.region.name if self.region else None
+        region_part = self.region.name if self.region else None
 
         # If we have a city, we won't use the country. If we have a region, but no city
         # we'll use the ISO country code. If we just have a country we'll use the full name

--- a/games/templates/games/game_list.html
+++ b/games/templates/games/game_list.html
@@ -47,6 +47,42 @@
     {% endfor %}
 </div>
 
+<nav aria-label="Game pagination">
+    <ul class="pagination justify-content-center mt-4">
+      {% if page_obj.has_previous %}
+        <li class="page-item">
+          <a class="page-link" href="?page={{ page_obj.previous_page_number }}" aria-label="Previous">
+            &laquo;
+          </a>
+        </li>
+      {% else %}
+        <li class="page-item disabled">
+          <span class="page-link">&laquo;</span>
+        </li>
+      {% endif %}
+
+      {% for num in page_obj.paginator.page_range %}
+        {% if num == page_obj.number %}
+          <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+        {% elif num >= page_obj.number|add:-2 and num <= page_obj.number|add:2 %}
+          <li class="page-item"><a class="page-link" href="?page={{ num }}">{{ num }}</a></li>
+        {% endif %}
+      {% endfor %}
+
+      {% if page_obj.has_next %}
+        <li class="page-item">
+          <a class="page-link" href="?page={{ page_obj.next_page_number }}" aria-label="Next">
+            &raquo;
+          </a>
+        </li>
+      {% else %}
+        <li class="page-item disabled">
+          <span class="page-link">&raquo;</span>
+        </li>
+      {% endif %}
+    </ul>
+</nav>
+
 <style>
     .hover-shadow {
         transition: box-shadow 0.3s ease-in-out;

--- a/games/templates/games/game_list.html
+++ b/games/templates/games/game_list.html
@@ -11,7 +11,7 @@
 </div>
 
 <div class="row g-4">
-    {% for game in games %}
+    {% for game in page_obj %}
     <div class="col-12">
         <a href="{% url 'game_detail' slug=game.slug %}" class="text-decoration-none text-body">
             <div class="card bg-body-tertiary border h-100 hover-shadow transition">

--- a/games/templates/games/game_list.html
+++ b/games/templates/games/game_list.html
@@ -14,7 +14,7 @@
     {% for game in page_obj %}
     <div class="col-12">
         <a href="{% url 'game_detail' slug=game.slug %}" class="text-decoration-none text-body">
-            <div class="card bg-body-tertiary border h-100 hover-shadow transition">
+            <div class="card bg-body-tertiary border h-100 btn-hover-scale transition">
                 <div class="row g-0 h-100">
                     <div class="col-4 d-flex align-items-center">
                         {% if game.logo %}
@@ -83,12 +83,4 @@
     </ul>
 </nav>
 
-<style>
-    .hover-shadow {
-        transition: box-shadow 0.3s ease-in-out;
-    }
-    .hover-shadow:hover {
-        box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-    }
-</style>
 {% endblock %}

--- a/games/tests.py
+++ b/games/tests.py
@@ -235,14 +235,40 @@ class GameListViewTest(TestCase):
         response = self.client.get(reverse("game_list"))
         self.assertTemplateUsed(response, "games/game_list.html")
 
-    def test_view_returns_all_games(self):
+    def test_view_returns_paginated_games(self):
+        # Create additional games to exceed the pagination limit
+        for i in range(10):
+            Game.objects.create(
+                name=f"Game {i + 3}",
+                game_format=Game.GameFormat.AMAZING_RACE,
+                active=True,
+                country=self.country,
+            )
+
         response = self.client.get(reverse("game_list"))
         self.assertEqual(response.status_code, 200)
-        self.assertIn(self.game1, response.context["games"])
-        self.assertIn(self.game2, response.context["games"])
+        self.assertEqual(len(response.context["page_obj"]), 10)
+        self.assertIn(self.game1, response.context["page_obj"])
+        self.assertIn(self.game2, response.context["page_obj"])
 
     def test_view_handles_no_games(self):
         Game.objects.all().delete()  # Remove all games
         response = self.client.get(reverse("game_list"))
         self.assertEqual(response.status_code, 200)
-        self.assertQuerySetEqual(response.context["games"], [])
+        self.assertQuerySetEqual(response.context["page_obj"], [])
+
+    def test_view_handles_second_page(self):
+        # Create additional games to exceed the pagination limit
+        for i in range(15):
+            Game.objects.create(
+                name=f"Game {i + 3}",
+                game_format=Game.GameFormat.AMAZING_RACE,
+                active=True,
+                country=self.country,
+            )
+
+        response = self.client.get(reverse("game_list") + "?page=2")
+        self.assertEqual(response.status_code, 200)
+        self.assertGreater(
+            len(response.context["page_obj"]), 0
+        )  # Ensure second page has games

--- a/games/tests.py
+++ b/games/tests.py
@@ -166,7 +166,7 @@ class GameLocationDisplayTests(TestCase):
         game = Game.objects.create(
             name="Test Game", country=self.country, region=self.region, city=self.city
         )
-        self.assertEqual(game.location_display(), "Los Angeles, CA")
+        self.assertEqual(game.location_display(), "Los Angeles, California")
 
     def test_location_display_with_region_country(self):
         game = Game.objects.create(

--- a/games/views.py
+++ b/games/views.py
@@ -1,11 +1,15 @@
+from django.core.paginator import Paginator
 from django.shortcuts import render
 
 from games.models import Game
 
 
 def game_list(request):
-    games = Game.objects.all()
-    return render(request, "games/game_list.html", {"games": games})
+    game_queryset = Game.objects.all().order_by("name")  # or whatever ordering
+    paginator = Paginator(game_queryset, 10)  # 10 games per page
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
+    return render(request, "games/game_list.html", {"page_obj": page_obj})
 
 
 def game_detail(request, slug):

--- a/templates/base.html
+++ b/templates/base.html
@@ -113,7 +113,7 @@
 </head>
 <body class="d-flex flex-column min-vh-100">
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg bg-primary" data-bs-theme="dark">
+    <nav class="navbar navbar-expand-lg bg-primary sticky-top" data-bs-theme="dark">
         <div class="container">
             <a class="navbar-brand" href="/">LRG Network</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">


### PR DESCRIPTION
1. Sticky Header (on base template)
2. Use full region name. I noticed that for some countries (e.g. Canada) the geoname code was a number (e.g. 02) instead of the abbreviation (e.g. BC)
3. Add pagination to the games page. Currently set to 10 (mostly for ease of testing) but we can bump this up if we want
4. Use same styling on game cards as on the buttons (from the game page)