### PR TITLE
Improved style for pagination

### DIFF
--- a/games/templates/games/game_list.html
+++ b/games/templates/games/game_list.html
@@ -48,7 +48,7 @@
 </div>
 
 <nav aria-label="Game pagination">
-    <ul class="pagination justify-content-center mt-4">
+    <ul class="pagination minimalist-pagination justify-content-center mt-4">
       {% if page_obj.has_previous %}
         <li class="page-item">
           <a class="page-link" href="?page={{ page_obj.previous_page_number }}" aria-label="Previous">

--- a/templates/base.html
+++ b/templates/base.html
@@ -107,6 +107,55 @@
             background-color: #0d6efd !important;
             border-color: #0d6efd !important;
         }
+
+        /* Pagination styles */
+        .minimalist-pagination .page-link {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 2.5rem;
+            height: 2.5rem;
+            margin: 0 0.25rem;
+            padding: 0;
+            background: none;
+            border: none;
+            border-radius: 50%; /* Ensure circular shape */
+            color: #333;
+            font-weight: 500;
+            transition: all 0.2s ease-in-out;
+        }
+
+        .minimalist-pagination .page-link:hover {
+            background-color: rgba(0, 0, 0, 0.05); /* Subtle gray circle */
+            color: #000;
+            border-radius: 50%; /* Explicitly apply border-radius */
+        }
+
+        .minimalist-pagination .active .page-link {
+            background-color: #198754;
+            color: white;
+            font-weight: 600;
+            box-shadow: none;
+        }
+
+        .minimalist-pagination .page-item {
+            border-radius: 50%; /* Ensure the parent container is circular */
+            overflow: hidden; /* Clip any child content that overflows */
+        }
+
+        .minimalist-pagination .page-item .page-link {
+            border-radius: 50%; /* Ensure the link itself is circular */
+        }
+
+        .minimalist-pagination .disabled .page-link {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+
+        .minimalist-pagination .page-link:focus {
+            box-shadow: none !important;
+            outline: none !important;
+        }
     </style>
 
     {% block extra_css %}{% endblock %}


### PR DESCRIPTION
Prior to these changes:
<img width="163" alt="Screenshot 2025-05-26 at 11 22 14 AM" src="https://github.com/user-attachments/assets/3afb5f44-2abb-4e54-9661-d4c99347ab49" />

After these changes:
<img width="188" alt="Screenshot 2025-05-26 at 11 22 26 AM" src="https://github.com/user-attachments/assets/d3f1753f-b605-4a5a-b4c0-5a336c459c74" />
