### PR TITLE
Type ahead search for filters

### DIFF
--- a/games/admin.py
+++ b/games/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from core.admin_mixins import AuditAdminMixin
 from cities_light.models import Country, Region, City, SubRegion
 
-from games.form import GameAdminForm
+from games.form import GameFilterForm
 from .models import Game, GameDate, GameImages, Season
 
 admin.site.unregister(Country)
@@ -46,7 +46,7 @@ class GameImagesInline(admin.TabularInline):
 
 @admin.register(Game)
 class GameAdmin(AuditAdminMixin):
-    form = GameAdminForm
+    form = GameFilterForm
     inlines = [GameDateInline, SeasonInline, GameImagesInline]
     exclude = ("slug",)
 

--- a/games/admin.py
+++ b/games/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from core.admin_mixins import AuditAdminMixin
 from cities_light.models import Country, Region, City, SubRegion
 
-from games.form import GameFilterForm
+from games.form import GameAdminForm
 from .models import Game, GameDate, GameImages, Season
 
 admin.site.unregister(Country)
@@ -46,7 +46,7 @@ class GameImagesInline(admin.TabularInline):
 
 @admin.register(Game)
 class GameAdmin(AuditAdminMixin):
-    form = GameFilterForm
+    form = GameAdminForm
     inlines = [GameDateInline, SeasonInline, GameImagesInline]
     exclude = ("slug",)
 

--- a/games/form.py
+++ b/games/form.py
@@ -1,10 +1,9 @@
 from django import forms
 from dal import autocomplete
-from cities_light.models import Country, Region, City
 from .models import Game
 
 
-class GameAdminForm(forms.ModelForm):
+class GameFilterForm(forms.ModelForm):
     class Meta:
         model = Game
         fields = "__all__"

--- a/games/form.py
+++ b/games/form.py
@@ -3,7 +3,7 @@ from dal import autocomplete
 from .models import Game
 
 
-class GameFilterForm(forms.ModelForm):
+class GameAdminForm(forms.ModelForm):
     class Meta:
         model = Game
         fields = "__all__"

--- a/games/templates/games/game_list.html
+++ b/games/templates/games/game_list.html
@@ -38,7 +38,7 @@
     <div class="row g-3 align-items-end mt-0">
         <div class="col-md-4">
             <label for="country" class="form-label">Country</label>
-            <select id="country" name="country" class="form-select">
+            <select id="country" name="country" class="selectpicker" data-live-search="true">
                 <option value="">All</option>
                 {% for country in countries %}
                     <option value="{{ country.id }}" {% if country.id|stringformat:"s" == selected_country %}selected{% endif %}>{{ country.name }}</option>
@@ -47,7 +47,7 @@
         </div>
         <div class="col-md-4">
             <label for="region" class="form-label">State/Region</label>
-            <select id="region" name="region" class="form-select" {% if not selected_country %}disabled{% endif %}>
+            <select id="region" name="region" class="selectpicker" data-live-search="true" data-size="10" {% if not selected_country %}disabled{% endif %}>
                 <option value="">All</option>
                 {% for region in regions %}
                     <option value="{{ region.id }}" {% if region.id|stringformat:"s" == selected_region %}selected{% endif %}>{{ region.name }}</option>
@@ -56,7 +56,7 @@
         </div>
         <div class="col-md-4">
             <label for="city" class="form-label">City</label>
-            <select id="city" name="city" class="form-select" {% if not selected_region %}disabled{% endif %} onchange="submitFormWithNonEmptyParams()">
+            <select id="city" name="city" class="selectpicker" data-live-search="true" data-size="10" {% if not selected_region %}disabled{% endif %} onchange="submitFormWithNonEmptyParams()">
                 <option value="">All</option>
                 {% for city in cities %}
                     <option value="{{ city.id }}" {% if city.id|stringformat:"s" == selected_city %}selected{% endif %}>{{ city.name }}</option>
@@ -68,7 +68,7 @@
     <div class="row g-3 align-items-end mt-0">
         <div class="col-md-4">
             <label for="game_format" class="form-label">Game Format</label>
-            <select id="game_format" name="game_format" class="form-select" onchange="submitFormWithNonEmptyParams()">
+            <select id="game_format" name="game_format" class="selectpicker" onchange="submitFormWithNonEmptyParams()">
                 <option value="">All</option>
                 {% for format in game_formats %}
                     <option value="{{ format.0 }}" {% if format.0 == selected_game_format %}selected{% endif %}>{{ format.1 }}</option>
@@ -78,7 +78,7 @@
 
         <div class="col-md-4">
             <label for="game_duration" class="form-label">Game Duration</label>
-            <select id="game_duration" name="game_duration" class="form-select" onchange="submitFormWithNonEmptyParams()">
+            <select id="game_duration" name="game_duration" class="selectpicker" onchange="submitFormWithNonEmptyParams()">
                 <option value="">All</option>
                 {% for duration in game_durations %}
                     <option value="{{ duration.0 }}" {% if duration.0 == selected_game_duration %}selected{% endif %}>{{ duration.1 }}</option>
@@ -88,7 +88,7 @@
 
         <div class="col-md-4">
             <label for="filming_status" class="form-label">Filming Status</label>
-            <select id="filming_status" name="filming_status" class="form-select" onchange="submitFormWithNonEmptyParams()">
+            <select id="filming_status" name="filming_status" class="selectpicker" onchange="submitFormWithNonEmptyParams()">
                 <option value="">All</option>
                 {% for status in filming_statuses %}
                     <option value="{{ status.0 }}" {% if status.0 == selected_filming_status %}selected{% endif %}>{{ status.1 }}</option>
@@ -201,6 +201,10 @@
 </nav>
 
 <script>
+    $(function () {
+        $('.selectpicker').selectpicker();
+    });
+
     const form = document.querySelector('form');
 
     function submitFormWithNonEmptyParams() {

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,11 +18,15 @@
 
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    {% compress css %}
-    <link rel="stylesheet" href="/static/games/styles.css">
-    {% endcompress %}
 
-    {% block extra_css %}{% endblock %}
+    <!-- Bootstrap Select -->
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <link rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.14.0-beta3/dist/css/bootstrap-select.min.css">
+
+    {% compress css %}
+        <link rel="stylesheet" href="/static/games/styles.css">
+    {% endcompress %}
 </head>
 <body class="d-flex flex-column min-vh-100">
     <!-- Navigation -->
@@ -58,6 +62,6 @@
         </div>
     </footer>
 
-    {% block extra_js %}{% endblock %}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.14.0-beta3/dist/js/bootstrap-select.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
For the location filters, we want to be able to have type-ahead searching to easily find a country/state/city. 

In order to do this, I switched to using bootstrap-select & selectpicker. I updated all filters to use the selectpicker so that they look the same visually, even if they don't use type-ahead search. 