### PR TITLE
Move admin page

### DIFF
--- a/lrgnetwork/urls.py
+++ b/lrgnetwork/urls.py
@@ -24,7 +24,7 @@ from django.views.generic import TemplateView
 
 urlpatterns = [
     path("", lambda request: HttpResponseRedirect("/games/")),  # Redirect home to games
-    path("admin/", admin.site.urls),
+    path("game-management/", admin.site.urls),
     path("games/", include("games.urls")),
     path(
         "about/",


### PR DESCRIPTION
Move admin page off the default URL for improved security. 

I had planned to setup Django Admin Honeypot on the `admin/` url, but it is not compatible with Django 4.0