### PR TITLE
Validate file size after optimization

### DIFF
--- a/games/models.py
+++ b/games/models.py
@@ -9,7 +9,7 @@ from django.core.files.base import ContentFile
 from PIL import Image
 
 from lrgnetwork.storage_backends import MediaStorage
-from .validators import validate_image
+from .validators import validate_image, validate_optimized_file_size
 from .utils import optimize_image
 
 from core.models import CoreModel
@@ -128,6 +128,7 @@ class Game(CoreModel):
 
         if self.logo:
             optimized = optimize_image(self.logo)
+            validate_optimized_file_size(optimized)
             self.logo.save(self.logo.name, optimized, save=False)
 
         super().save(*args, **kwargs)
@@ -195,6 +196,7 @@ class GameImages(CoreModel):
     def save(self, *args, **kwargs):
         if self.image:
             optimized = optimize_image(self.image)
+            validate_optimized_file_size(optimized)
             self.image.save(self.image.name, optimized, save=False)
 
         super().save(*args, **kwargs)

--- a/games/validators.py
+++ b/games/validators.py
@@ -3,18 +3,24 @@ from PIL import Image
 
 
 def validate_image(file):
-    max_size = 2 * 1024 * 1024  # 2MB limit
-    if file.size > max_size:
-        raise ValidationError("Image file too large (max 2MB).")
-
+    # Only check that the file is a valid image and has a supported extension
     try:
         img = Image.open(file)
         img.verify()  # Verify that it's a valid image
     except Exception:
         raise ValidationError("Uploaded file is not a valid image.")
 
-    # Optionally check file extension if you want
     valid_extensions = ["jpg", "jpeg", "png", "webp"]
     ext = file.name.split(".")[-1].lower()
     if ext not in valid_extensions:
         raise ValidationError(f"Unsupported file extension: {ext}")
+
+
+def validate_optimized_file_size(content_file, max_size=2 * 1024 * 1024):
+    """
+    Checks the size of the optimized ContentFile. Raises ValidationError if too large.
+    """
+    if content_file.size > max_size:
+        raise ValidationError(
+            "Optimized image file too large (max 2MB after optimization)."
+        )


### PR DESCRIPTION
We were getting errors that photos were too big even though we have image optimization in place. I realized the validator checks the original file size, not the optimized image. 

This PR drops the size check from the validator, and then validates the file size after optimization. 

I tested this on my local dev and confirmed that a 3MB file failed before this change, but uploads (and is only 453KB) after this change